### PR TITLE
Update UnitConverterUNECERec20.js

### DIFF
--- a/js/UnitConverterUNECERec20.js
+++ b/js/UnitConverterUNECERec20.js
@@ -535,7 +535,8 @@ class UnitConverterUNECERec20 {
 		{"rec20":"P76","name":"microsievert per minute","symbol":"µSv/min","multiplier":1.666666667e-8,"offset":0,"type":"effective dose rate"},
 		{"rec20":"P77","name":"nanosievert per minute","symbol":"nSv/min","multiplier":1.666666667e-11,"offset":0,"type":"effective dose rate"},
 		
-
+		{"rec20":"B7","name":"cycle","type":"count"}
+			
 		];
 	}
 


### PR DESCRIPTION
Added "B7" (cycle) which is defined by UN/CEFACT as "A unit of count defining the number of cycles (cycle: a recurrent period of definite duration)."
To be discussed: (a) "count" as type, (b) whether it is acceptable to have a dict entry with no symbol, multiplier or offset information included.